### PR TITLE
fix: dropdown width

### DIFF
--- a/src/components/pageComponents/home/Examples/demos/EnsNameDemo.tsx
+++ b/src/components/pageComponents/home/Examples/demos/EnsNameDemo.tsx
@@ -72,7 +72,7 @@ const ENSName = styled.div`
 
 const ButtonText = styled.span`
   display: block;
-  max-width: 100px;
+  max-width: 115px;
   overflow: hidden;
   text-overflow: ellipsis;
 `


### PR DESCRIPTION
# Description:

Dropdown button in ENS demo currently looks like this:

![image](https://github.com/user-attachments/assets/8d8f45d1-6075-4562-9c09-1f407f0bd155)

Changed the width so it looks like this:

![image](https://github.com/user-attachments/assets/15127ae7-7305-4542-a0c4-0e0c286b13e1)

![image](https://github.com/user-attachments/assets/a2981c8d-2e20-47cf-8caa-73a8ca6845ee)

## Type of change:

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Enhancement
- [ ] Refactoring
- [ ] Chore

# How Has This Been Tested?

- [x] Manual testing
- [ ] Automated tests
- [ ] Other (explain)